### PR TITLE
Cleaning up timeline to move logic into a hook and persist some things

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,0 +1,74 @@
+import React, { FunctionComponent } from "react"
+import { theme } from "reactotron-core-ui"
+import styled, { ThemeProvider } from "styled-components"
+
+import useTimeline from "./hooks/useTimeline"
+import Timeline from "./Timeline"
+import Subscriptions from "./Subscriptions"
+
+import logo from "../logo"
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background-color: ${props => props.theme.background};
+`
+
+const FooterContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  background-color: ${props => props.theme.backgroundSubtleLight};
+  border-top: 1px solid ${props => props.theme.chromeLine};
+  color: ${props => props.theme.foregroundDark};
+  height: 35px;
+  padding: 10px;
+`
+
+interface Props {
+  commands: any[]
+  onTab: "timeline" | "subscriptions"
+  onSendCommand: (command: any) => void
+  onClearCommands: () => void
+  onChangeTab: (tab: "timeline" | "subscriptions") => void
+}
+
+const Main: FunctionComponent<Props> = ({
+  commands,
+  onTab,
+  onSendCommand,
+  onClearCommands,
+  onChangeTab,
+}) => {
+  const timelineHandler = useTimeline()
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Container>
+        {onTab === "timeline" && (
+          <Timeline
+            commands={commands}
+            onSendCommand={onSendCommand}
+            onClearCommands={onClearCommands}
+            onChangeTab={onChangeTab}
+            {...timelineHandler}
+          />
+        )}
+        {onTab === "subscriptions" && (
+          <Subscriptions
+            commands={commands}
+            onSendCommand={onSendCommand}
+            onChangeTab={onChangeTab}
+          />
+        )}
+        <FooterContainer>
+          <img src={`data:image/png;base64, ${logo}`} height={30} />
+        </FooterContainer>
+      </Container>
+    </ThemeProvider>
+  )
+}
+
+export default Main

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from "react"
+import React, { FunctionComponent } from "react"
 import { clipboard } from "electron"
 import fs from "fs"
-import { timelineCommandResolver, filterCommands, TimelineFilterModal } from "reactotron-core-ui"
+import {
+  timelineCommandResolver,
+  filterCommands,
+  TimelineFilterModal,
+  CommandType,
+} from "reactotron-core-ui"
 import styled from "styled-components"
 import { MdSearch, MdDeleteSweep, MdVpnKey, MdFilterList, MdSwapVert } from "react-icons/md"
 
@@ -39,20 +44,40 @@ interface Props {
   onSendCommand: (command: any) => void
   onClearCommands: () => void
   onChangeTab: (tab: "timeline" | "subscriptions") => void
+  // Timeline Handler things
+  isSearchOpen: boolean
+  toggleSearch: () => void
+  search: string
+  setSearch: (search: string) => void
+  isFilterOpen: boolean
+  openFilter: () => void
+  closeFilter: () => void
+  isReversed: boolean
+  toggleReverse: () => void
+  hiddenCommands: CommandType[]
+  setHiddenCommands: (hiddenCommands: CommandType[]) => void
 }
 
-function Timeline({ commands, onSendCommand, onClearCommands, onChangeTab }: Props) {
-  // TODO: Switch to a reducer
-  // TODO: Persist some of these (like if the timeline is reversed) and load when we mount.
-  const [isSearchOpen, setIsSearchOpen] = useState(false)
-  const [isFilterModalOpen, setIsFilterModalOpen] = useState(false)
-  const [isTimelineReversed, setIsTimelineReversed] = useState(false)
-  const [hiddenCommands, setHiddenCommands] = useState([])
-  const [search, setSearch] = useState("")
-
+const Timeline: FunctionComponent<Props> = ({
+  commands,
+  onSendCommand,
+  onClearCommands,
+  onChangeTab,
+  isSearchOpen,
+  toggleSearch,
+  search,
+  setSearch,
+  isFilterOpen,
+  openFilter,
+  closeFilter,
+  isReversed,
+  toggleReverse,
+  hiddenCommands,
+  setHiddenCommands,
+}) => {
   let filteredCommands = filterCommands(commands, search, hiddenCommands)
 
-  if (isTimelineReversed) {
+  if (isReversed) {
     filteredCommands = filteredCommands.reverse()
   }
 
@@ -65,7 +90,7 @@ function Timeline({ commands, onSendCommand, onClearCommands, onChangeTab }: Pro
             tip: "Search",
             icon: MdSearch,
             onClick: () => {
-              setIsSearchOpen(!isSearchOpen)
+              toggleSearch()
             },
           },
           {
@@ -82,14 +107,14 @@ function Timeline({ commands, onSendCommand, onClearCommands, onChangeTab }: Pro
             tip: "Filter",
             icon: MdFilterList,
             onClick: () => {
-              setIsFilterModalOpen(true)
+              openFilter()
             },
           },
           {
             tip: "Reverse Order",
             icon: MdSwapVert,
             onClick: () => {
-              setIsTimelineReversed(!isTimelineReversed)
+              toggleReverse()
             },
           },
           {
@@ -111,7 +136,7 @@ function Timeline({ commands, onSendCommand, onClearCommands, onChangeTab }: Pro
         )}
       </Header>
       <TimelineContainer>
-        {filteredCommands.map((command, idx) => {
+        {filteredCommands.map(command => {
           const CommandComponent = timelineCommandResolver(command.type)
 
           if (CommandComponent) {
@@ -137,9 +162,9 @@ function Timeline({ commands, onSendCommand, onClearCommands, onChangeTab }: Pro
         })}
       </TimelineContainer>
       <TimelineFilterModal
-        isOpen={isFilterModalOpen}
+        isOpen={isFilterOpen}
         onClose={() => {
-          setIsFilterModalOpen(false)
+          closeFilter()
         }}
         hiddenCommands={hiddenCommands}
         setHiddenCommands={setHiddenCommands}

--- a/src/hooks/useTimeline.tsx
+++ b/src/hooks/useTimeline.tsx
@@ -1,0 +1,137 @@
+import { useReducer, useEffect } from "react"
+import { CommandType } from "reactotron-core-ui"
+
+enum StorageKey {
+  ReversedOrder = "ReactotronTimelineReversedOrder",
+  HiddenCommands = "ReactotronTimelineHiddenCommands",
+}
+
+interface TimelineState {
+  isSearchOpen: boolean
+  search: string
+  isFilterOpen: boolean
+  isReversed: boolean
+  hiddenCommands: CommandType[]
+}
+
+interface TimelineAction {
+  type:
+    | "SEARCH_OPEN"
+    | "SEARCH_CLOSE"
+    | "SEARCH_SET"
+    | "FILTER_OPEN"
+    | "FILTER_CLOSE"
+    | "ORDER_REVERSE"
+    | "ORDER_REGULAR"
+    | "HIDDENCOMMANDS_SET"
+  payload?: string | CommandType[]
+}
+
+function timelineReducer(state: TimelineState, action: TimelineAction) {
+  switch (action.type) {
+    case "SEARCH_OPEN":
+      return { ...state, isSearchOpen: true }
+    case "SEARCH_CLOSE":
+      return { ...state, isSearchOpen: false }
+    case "SEARCH_SET":
+      return { ...state, search: action.payload as string }
+    case "FILTER_OPEN":
+      return { ...state, isFilterOpen: true }
+    case "FILTER_CLOSE":
+      return { ...state, isFilterOpen: false }
+    case "ORDER_REVERSE":
+      return { ...state, isReversed: true }
+    case "ORDER_REGULAR":
+      return { ...state, isReversed: false }
+    case "HIDDENCOMMANDS_SET":
+      return { ...state, hiddenCommands: action.payload as CommandType[] }
+    default:
+      return state
+  }
+}
+
+function useTimeline() {
+  const [state, dispatch] = useReducer(timelineReducer, {
+    isSearchOpen: false,
+    search: "",
+    isFilterOpen: false,
+    isReversed: false,
+    hiddenCommands: [],
+  })
+
+  // Load some values
+  useEffect(() => {
+    const isReversed = localStorage.getItem(StorageKey.ReversedOrder) === "reversed"
+    const hiddenCommands = JSON.parse(localStorage.getItem(StorageKey.HiddenCommands) || "[]")
+
+    dispatch({
+      type: isReversed ? "ORDER_REVERSE" : "ORDER_REGULAR",
+    })
+
+    dispatch({
+      type: "HIDDENCOMMANDS_SET",
+      payload: hiddenCommands,
+    })
+  }, [])
+
+  // Setup event handlers
+  const toggleSearch = () => {
+    dispatch({
+      type: state.isSearchOpen ? "SEARCH_CLOSE" : "SEARCH_OPEN",
+    })
+  }
+
+  const setSearch = (search: string) => {
+    dispatch({
+      type: "SEARCH_SET",
+      payload: search,
+    })
+  }
+
+  const openFilter = () => {
+    dispatch({
+      type: "FILTER_OPEN",
+    })
+  }
+
+  const closeFilter = () => {
+    dispatch({
+      type: "FILTER_CLOSE",
+    })
+  }
+
+  const toggleReverse = () => {
+    const isReversed = !state.isReversed
+
+    localStorage.setItem(StorageKey.ReversedOrder, isReversed ? "reversed" : "regular")
+
+    dispatch({
+      type: isReversed ? "ORDER_REVERSE" : "ORDER_REGULAR",
+    })
+  }
+
+  const setHiddenCommands = (hiddenCommands: CommandType[]) => {
+    localStorage.setItem(StorageKey.HiddenCommands, JSON.stringify(hiddenCommands))
+
+    dispatch({
+      type: "HIDDENCOMMANDS_SET",
+      payload: hiddenCommands,
+    })
+  }
+
+  return {
+    isSearchOpen: state.isSearchOpen,
+    toggleSearch,
+    search: state.search,
+    setSearch,
+    isFilterOpen: state.isFilterOpen,
+    openFilter,
+    closeFilter,
+    isReversed: state.isReversed,
+    toggleReverse,
+    hiddenCommands: state.hiddenCommands,
+    setHiddenCommands,
+  }
+}
+
+export default useTimeline

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,32 +1,8 @@
 import React from "react"
 import { FlipperPlugin } from "flipper"
-import { theme, repairSerialization } from "reactotron-core-ui"
-import styled, { ThemeProvider } from "styled-components"
+import { repairSerialization } from "reactotron-core-ui"
 
-import Timeline from "./Timeline"
-import Subscriptions from "./Subscriptions"
-
-
-import logo from "../logo"
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  background-color: ${props => props.theme.background};
-`
-
-const FooterContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  background-color: ${props => props.theme.backgroundSubtleLight};
-  border-top: 1px solid ${props => props.theme.chromeLine};
-  color: ${props => props.theme.foregroundDark};
-  height: 35px;
-  padding: 10px;
-`
+import Main from "./Main"
 
 interface PersistedState {
   commands: any[]
@@ -69,28 +45,13 @@ export default class extends FlipperPlugin<never, never, PersistedState> {
     const { commands, onTab } = this.props.persistedState
 
     return (
-      <ThemeProvider theme={theme}>
-        <Container>
-          {onTab === "timeline" && (
-            <Timeline
-              commands={commands}
-              onSendCommand={this.handleSendCommand}
-              onClearCommands={this.handleClearCommands}
-              onChangeTab={this.handleChangeTab}
-            />
-          )}
-          {onTab === "subscriptions" && (
-            <Subscriptions
-              commands={commands}
-              onSendCommand={this.handleSendCommand}
-              onChangeTab={this.handleChangeTab}
-            />
-          )}
-          <FooterContainer>
-        <img src={`data:image/png;base64, ${logo}`} height={30} />
-      </FooterContainer>
-        </Container>
-      </ThemeProvider>
+      <Main
+        commands={commands}
+        onTab={onTab}
+        onSendCommand={this.handleSendCommand}
+        onClearCommands={this.handleClearCommands}
+        onChangeTab={this.handleChangeTab}
+      />
     )
   }
 }


### PR DESCRIPTION
Now that a lot of the functionality of both the Timeline and Subscriptions tab are working I am beginning to cleanup the logic. This cleans up timeline to something I am happy with. Subscriptions will be cleaned up in a similar manner.

This is also implementing a "nice to have" feature of saving some settings for use across sessions.