### PR TITLE
Fix double scrollbar

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,21 @@ export default class extends FlipperPlugin<never, never, PersistedState> {
     }
   }
 
+  init() {
+    this.toggleScrollbar(false)
+  }
+
+  componentWillUnmount() {
+    this.toggleScrollbar(true)
+  }
+
+  toggleScrollbar = (show: boolean) => {
+    const flipperSidebar = document.getElementById("detailsSidebar")
+    if (flipperSidebar) {
+      flipperSidebar.style.overflow = show ? "scroll" : "hidden"
+    }
+  }
+
   handleSendCommand = (command: any) => {
     this.client.call("sendReactotronCommand", command)
   }


### PR DESCRIPTION
- Fixes the double scrollbar issue by changing `Sidebar` Flipper component's style. (Glad we don't have to make any changes to Flipper source code)
- Also, restores the scrollbar when the other plugin is selected. 

![scroll](https://user-images.githubusercontent.com/8325407/69280794-7471db80-0c2a-11ea-8b25-79eee274978e.gif)
