### PR TITLE
feat: Add dispatch action button to timeline

### DIFF
--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -17,6 +17,7 @@ import {
   MdSwapVert,
   MdReorder,
   MdVpnKey,
+  MdSend,
 } from "react-icons/md"
 import styled from "styled-components"
 
@@ -112,6 +113,13 @@ const Timeline: FunctionComponent<Props> = ({ onChangeTab }) => {
             icon: MdSearch,
             onClick: () => {
               toggleSearch()
+            },
+          },
+          {
+            tip: "Dispatch Action",
+            icon: MdSend,
+            onClick: () => {
+              openDispatchModal("")
             },
           },
           {


### PR DESCRIPTION
This PR adds a button (Dispatch Action) to the timeline. Because Flipper does not properly pass pressed hotkeys to the plugin (at least, not on the Timeline view with Flipper 0.42.0 on macOS), cmd+d to open the dispatch modal does not work, so another way to access this modal is necessary. 

Even if the hotkey did work, an extra button improves discoverability for a useful feature that new users of Reactotron may not know exists.